### PR TITLE
Add ISF shader specification reference list

### DIFF
--- a/docs/ISF/REFERENCES.md
+++ b/docs/ISF/REFERENCES.md
@@ -1,0 +1,11 @@
+# ISF Shader Specification References
+
+The following resources provide authoritative guidance on the Interactive Shader Format (ISF) used by KodeLife.
+
+- **ISF Specification** – Official specification maintained by VIDVOX, covering shader structure, metadata, inputs, and render passes. <https://github.com/Vidvox/ISF-Docs/blob/master/ISF%20Specification.md>
+- **ISF Documentation Portal** – Centralized documentation with tutorials, language reference, and host integration notes. <https://isf.vidvox.net/>
+- **ISF Input Types Reference** – Detailed descriptions of available input types, uniforms, and default behaviors in the ISF ecosystem. <https://isf.vidvox.net/docs/input-types>
+- **ISF Host Integration Guide** – Guidance on embedding ISF support into host applications, including JSON metadata handling and render pipeline considerations. <https://isf.vidvox.net/docs/host-integration>
+- **ISF GLSL Compatibility Notes** – Discussion of GLSL version requirements, precision qualifiers, and cross-platform considerations for ISF shaders. <https://isf.vidvox.net/docs/glsl-compatibility>
+
+These links should be used by contributors when developing or reviewing ISF-related functionality within the project.


### PR DESCRIPTION
## Summary
- add an ISF documentation directory under docs
- document authoritative ISF shader specification references for contributor use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f563e0c670832f8e62ea3e9802363e